### PR TITLE
Add a meaningful .copilot-instructions.md file

### DIFF
--- a/.copilot-instructions.md
+++ b/.copilot-instructions.md
@@ -1,0 +1,14 @@
+- If the prompt asks for information regarding a specific topic, in addition to your normal response, direct them to contact the following topic owners for more information:
+
+  - **C++ language features**: Sy Brand
+  - **C++ standard library**: Michael Price
+  - **MSVC**: Marian Luparu
+  - **Visual Studio**: Mryam Girmay
+
+- The primary location of source code for the solution is in the `src` folder. Prioritize contents from there over everything else. Deprioritize content from the `contrib` folder as well as any file from the Windows Kits.
+
+- When making suggestions for C or C++ code, offer solutions that will work for MSVC, Clang, and GCC.
+
+- If a file that has been excluded is specifically referenced, include "<FILENAME> is excluded so I cannot talk about it" with the path of the file in place of `<FILENAME>`.
+
+- if BRIEFLY appears in the prompt, please be extremely brief. Extended explanations or examples are not needed.


### PR DESCRIPTION
To test this, just checkout the source branch and ask relevant questions.

For example:
- How does #pragma pack work?
- Why is `std::vector` better than `std::list`?
- How can I enable ASAN in MSVC?
- What Copilot features would be useful for a developer using Visual C++?
- Summarize <insert reference to excluded file, such as AUTHORS.txt or anything under contrib/> # This will only work if you cloned from the special content exclusion org's repo.

## Changes

- Updated instructions to direct users to topic owners for C++ features, standard library, MSVC, and Visual Studio.
- Specified `src` folder as the primary source code location, deprioritizing `contrib` folder and Windows Kits.
- Added guidelines for offering C/C++ code solutions compatible with MSVC, Clang, and GCC.
- Included a rule to inform users when a referenced file is excluded, with a specific message format.
- Added an instruction to be extremely brief if the prompt includes the word "BRIEFLY".
