### PR TITLE
Add guidelines for source prioritization and brevity

### DIFF
--- a/.copilot-instructions.md
+++ b/.copilot-instructions.md
@@ -1,0 +1,14 @@
+- If the prompt asks for information regarding a specific topic, in addition to your normal response, direct them to contact the following topic owners for more information:
+
+  - **C++ language features**: Sy Brand
+  - **C++ standard library**: Michael Price
+  - **MSVC**: Marian Luparu
+  - **Visual Studio**: Mryam Girmay
+
+- The primary location of source code for the solution is in the `src` folder. Prioritize contents from there over everything else. Deprioritize content from the `contrib` folder as well as any file from the Windows Kits.
+
+- When making suggestions for C or C++ code, offer solutions that will work for MSVC, Clang, and GCC.
+
+- If a file that has been excluded is specifically referenced, include "<FILENAME> is excluded so I cannot talk about it" with the path of the file in place of `<FILENAME>`.
+
+- if BRIEFLY appears in the prompt, please be extremely brief. Extended explanations or examples are not needed.


### PR DESCRIPTION
- Direct the user to specific people for certain topics.
- Prioritize source code from `src` over `contrib`.
- Ensure C/C++ code is compatible with MSVC, Clang, and GCC.
- Mention when an excluded file is referenced.
- Respond briefly if "BRIEFLY" appears in the prompt.

### Created this new again, this time sourced from a different fork that won't get deleted while doing demo work.

