### PR TITLE
Adding text of GitHub Copilot prompts

### DIFF
--- a/DEMO_COPILOT_PROMPTS.txt
+++ b/DEMO_COPILOT_PROMPTS.txt
@@ -1,0 +1,9 @@
+BRIEFLY, what techniques are there to reduce memory padding in a C++ type?
+
+Who could I talk to if I wanted to learn more about #pragma pack?
+
+Is <insert-name> one of the authors in <insert-ref-to-authors-file> ?
+
+BRIEFLY, find some types in the `src/galaxy` directory of the <insert-ref-to-solution> that have padding that can be reduced with `#pragma pack``?
+
+How would I use `#pragma pack` to reduce memory padding for <insert-ref-to-class> ?


### PR DESCRIPTION
We don't want our typing skills (or lack thereof) to be memorialized on the Internet forever as fodder for any memes.