### PR TITLE
Enhance brevity and clarity in response instructions

### DIFF
--- a/.copilot-instructions.md
+++ b/.copilot-instructions.md
@@ -11,4 +11,4 @@
 
 - If a file that has been excluded is specifically referenced, include "<FILENAME> is excluded so I cannot talk about it" with the path of the file in place of `<FILENAME>`.
 
-- if BRIEFLY appears in the prompt, please be extremely brief. Extended explanations or examples are not needed.
+- Be extremely brief. Do not provide examples unless explicitly asked to provide examples or how to apply something to existing code. If responding with a list of things, just list the things, do not go into extended detail about each thing.


### PR DESCRIPTION
BRIEFLY is no longer required to appear in the prompt to request shorter answers.

