### PR TITLE
Prompt stash refinement

### DIFF
--- a/DEMO_COPILOT_PROMPTS.txt
+++ b/DEMO_COPILOT_PROMPTS.txt
@@ -1,9 +1,9 @@
-BRIEFLY, what techniques are there to reduce memory padding in a C++ type?
+What techniques are there to reduce memory padding in a C++ type?
 
 Who could I talk to if I wanted to learn more about #pragma pack?
 
-Is <insert-name> one of the authors in <insert-ref-to-authors-file> ?
+Is Sy one of the authors in 
 
-BRIEFLY, find some types in the `src/galaxy` directory of the <insert-ref-to-solution> that have padding that can be reduced with `#pragma pack``?
+Find some types in the `src/galaxy` directory that have padding that can be reduced with `#pragma pack`?
 
-How would I use `#pragma pack` to reduce memory padding for <insert-ref-to-class> ?
+How would I use `#pragma pack` to reduce memory padding for 


### PR DESCRIPTION
Making the prompts a bit eaiser to copy and paste and fill in blanks. Also removing 'BRIEFLY' markers which should no longer be needed.


